### PR TITLE
Create DESTDIR/usr/bin if it doesn't exist yet.

### DIFF
--- a/tk4/Makefile
+++ b/tk4/Makefile
@@ -46,4 +46,5 @@ clean:
 
 install:
 	strip $(CODENAME)
+	mkdir -p $(DESTDIR)/usr/bin/
 	cp $(CODENAME) $(DESTDIR)/usr/bin/

--- a/tk6/Makefile
+++ b/tk6/Makefile
@@ -46,4 +46,5 @@ clean:
 
 install:
 	strip $(CODENAME)
+	mkdir -p $(DESTDIR)/usr/bin/
 	cp $(CODENAME) $(DESTDIR)/usr/bin/

--- a/tumbleweed/Makefile
+++ b/tumbleweed/Makefile
@@ -29,4 +29,5 @@ clean:
 
 install:
 	strip $(CODENAME)
+	mkdir -p $(DESTDIR)/usr/bin/
 	cp $(CODENAME) $(DESTDIR)/usr/bin/


### PR DESCRIPTION
I went to install torrentkino to a location under my home directory, and it failed because $DESTDIR/usr/bin didn't exist yet.

The changes in this pull request quietly ensure $DESTDIR/usr/bin exists before copying files there.